### PR TITLE
Bumped version to 6.0.5 for next release

### DIFF
--- a/DNN_XML.dnn
+++ b/DNN_XML.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DNN_XML" type="Module" version="06.00.04">
+    <package name="DNN_XML" type="Module" version="06.00.05">
       <friendlyName>DNN XML Module</friendlyName>
       <description>
         The DNN XML module queries Data as XML and renders it.
@@ -14,7 +14,7 @@
       <license src="License.htm"/>
       <releaseNotes src="ReleaseNotes.htm" />
       <dependencies>
-        <dependency type="CoreVersion">07.04.02</dependency>
+        <dependency type="CoreVersion">08.00.00</dependency>
       </dependencies>
       <components>
         <component type="Cleanup" version="06.00.01" fileName="Cleanup_06.00.01.txt" />
@@ -43,8 +43,8 @@
         </component>
         <component type="Assembly">
           <assemblies>
-            <basePath>bin</basePath>
             <assembly>
+              <path>bin</path>
               <name>DotNetNuke.Modules.Xml.dll</name>
             </assembly>
           </assemblies>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -47,9 +47,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("6.0.4.0")]
+[assembly: AssemblyVersion("6.0.5.0")]
 [assembly: AssemblyDelaySign(false)]
 [assembly: AssemblyKeyFile("")]
 [assembly: AssemblyKeyName("")]
-[assembly: AssemblyFileVersion("6.0.4.0")]
+[assembly: AssemblyFileVersion("6.0.5.0")]
 

--- a/releasenotes.htm
+++ b/releasenotes.htm
@@ -1,54 +1,70 @@
 ﻿<h4>Release Notes</h4>
-<h2>DNN XML Module 06.00.04 </h2>
-<p>This release is compiled against the .Net 4.5 Framework using VS2015.<br />The minimum DNNPlatform version is 7.4.2 </p>
+<h2>DNN XML Module 06.00.06 </h2>
+<p>This release is compiled against the .Net 4.5 Framework using VS2015.<br />The minimum DNNPlatform version is 8.0.0 </p>
+<h4>06.00.05</h4>
+<ul>
+    <li>Source code dependencies are now pulled from Nuget</li>
+</ul>
 <h4>06.00.04</h4>
 <ul>
-	<li>Support for embedded script blocks can be enabled in web.config by setting enableScript="true" 
-	in web config for xslCompiledTransformProvider</li>
-	<li>Minimal fix to build with in DNN 7.4.2</li>
-	<li>Retargeted .NET Framework to v4.5</li>
-	<li>Converted to VS2015</li>
+    <li>
+        Support for embedded script blocks can be enabled in web.config by setting enableScript="true"
+        in web config for xslCompiledTransformProvider
+    </li>
+    <li>Minimal fix to build with in DNN 7.4.2</li>
+    <li>Retargeted .NET Framework to v4.5</li>
+    <li>Converted to VS2015</li>
 </ul>
 <h4>06.00.03</h4>
 <ul>
-	<li>Fix: Layout information has been ignored, preventing output like csv.</li>
-	<li>document() function can be enabled in web.config by setting enableDocument="true" in web config 
-	for xslCompiledTransformProvider</li>
-	<li>Converted to VS2012</li>
+    <li>Fix: Layout information has been ignored, preventing output like csv.</li>
+    <li>
+        document() function can be enabled in web.config by setting enableDocument="true" in web config
+        for xslCompiledTransformProvider
+    </li>
+    <li>Converted to VS2012</li>
 </ul>
 <h4>06.00.02</h4>
 <ul>
-	<li>HttpRequest did not work in Medium Trust</li>
+    <li>HttpRequest did not work in Medium Trust</li>
 </ul>
 <h4>06.00.01</h4>
 <ul>
-	<li>This release circumvents a bug in DNN6.0.0 which stopped the HttpRequest provider. It introduces 
-	no new features.</li>
+    <li>
+        This release circumvents a bug in DNN6.0.0 which stopped the HttpRequest provider. It introduces
+        no new features.
+    </li>
 </ul>
 <h4>06.00.00</h4>
 New Features
 <ul>
-	<li>Data Sources and Rendering are now implemented as providers. New data sources and rendering 
-	engines can be added as DotNetNuke providers</li>
-	<li>HttpRequest-provider<ul>
-		<li>Cacheable DataSources</li>
-		<li>URL can be defined using TokenReplace</li>
-	</ul>
-	</li>
-	<li>XslCompiledTransform-provider supports now new XSLT Extension object. These actions are currently 
-	supported:<ul>
-		<li>setting of page title, page description, module title, </li>
-		<li>loading of CSS and javascript files and statements,</li>
-		<li>calling TokenReplace to query additonal contect information</li>
-	</ul>
-	</li>
+    <li>
+        Data Sources and Rendering are now implemented as providers. New data sources and rendering
+        engines can be added as DotNetNuke providers
+    </li>
+    <li>
+        HttpRequest-provider<ul>
+            <li>Cacheable DataSources</li>
+            <li>URL can be defined using TokenReplace</li>
+        </ul>
+    </li>
+    <li>
+        XslCompiledTransform-provider supports now new XSLT Extension object. These actions are currently
+        supported:<ul>
+            <li>setting of page title, page description, module title, </li>
+            <li>loading of CSS and javascript files and statements,</li>
+            <li>calling TokenReplace to query additonal contect information</li>
+        </ul>
+    </li>
 </ul>
 New Architecture
 <ul>
-	<li>The module switched from VB.NET to C#</li>
-	<li>The project was converted from WSP to a Web Application Project (WAP) </li>
-	<li>VS2010 project file</li>
-	<li>Automatic package creation using MsBuild. Source package requires
-	<a href="http://msbuildtasks.tigris.org/">msbuildtasks</a> </li>
-	<li>Providers build on DotNetNuke.Components, fully supporting DotNetNuke extension model</li>
+    <li>The module switched from VB.NET to C#</li>
+    <li>The project was converted from WSP to a Web Application Project (WAP) </li>
+    <li>VS2010 project file</li>
+    <li>
+        Automatic package creation using MsBuild. Source package requires
+        <a href="http://msbuildtasks.tigris.org/">msbuildtasks</a>
+    </li>
+    <li>Providers build on DotNetNuke.Components, fully supporting DotNetNuke extension model</li>
 </ul>


### PR DESCRIPTION
and , fixed wrong assembly node in manifest (for EVS)

This commit was missing from my previous pull request...